### PR TITLE
FIX:compatibility issue in gtf2bed.R for mouse annotation

### DIFF
--- a/scripts/Auxiliary/gtf2bed.R
+++ b/scripts/Auxiliary/gtf2bed.R
@@ -27,7 +27,7 @@ exons_temp = exonicParts(txdb)
 temp = as.data.frame(exons_temp)
 temp = temp[,c(1:5,8)]
 temp[,"gene_id"] = sapply(temp[,"gene_id"], `[[`, 1)
-temp[,"gene_id"] = substr(temp[,"gene_id"],1,15)
+temp[,"gene_id"] = gsub("\\..*$", "", temp[,"gene_id"])
 colnames(temp)[1] <- c("chr")
 
 core_avai = parallel::detectCores()


### PR DESCRIPTION
This commit addresses and resolves a bug where the gtf2bed.R  was previously tailored for human gene_id and failed with mouse genome data due to differences in gene_id sizes. The script is now compatible with both human and mouse genome annotations.